### PR TITLE
ME-1897: remove policy attachment from state if policy not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     border0 = {
       source  = "borderzero/border0"
-      version = "0.1.6"
+      version = "0.1.7"
     }
   }
 }

--- a/border0/resource_policy_attachment.go
+++ b/border0/resource_policy_attachment.go
@@ -3,6 +3,7 @@ package border0
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 
 	border0client "github.com/borderzero/border0-go/client"
@@ -48,6 +49,11 @@ func resourcePolicyAttachmentRead(ctx context.Context, d *schema.ResourceData, m
 	policyID, socketID := ids[0], ids[1]
 
 	policy, err := client.Policy(ctx, policyID)
+	if !d.IsNewResource() && border0client.NotFound(err) {
+		log.Printf("[WARN] Policy (%s) not found, removing from state", policyID)
+		d.SetId("")
+		return nil
+	}
 	if err != nil {
 		return schemautil.DiagnosticsError(err, "Failed to fetch policy")
 	}

--- a/examples/connector_and_sockets/main.tf
+++ b/examples/connector_and_sockets/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     border0 = {
       source  = "borderzero/border0"
-      version = "0.1.6"
+      version = "0.1.7"
     }
   }
 }

--- a/examples/just_sockets/main.tf
+++ b/examples/just_sockets/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     border0 = {
       source  = "borderzero/border0"
-      version = "0.1.6"
+      version = "0.1.7"
     }
   }
 }


### PR DESCRIPTION
when the policy is removed manually, or by another TF config module that manages the policy and policy attachment separately, and the policy got removed before running the config that manages policy attachment. in either cases, policy attachment resource should be able to ignore the api error when the policy is not found, and automatically remove the policy attachment from the terraform state