### PR TITLE
ME-1960: connector managed ssh service id

### DIFF
--- a/border0/resource_connector.go
+++ b/border0/resource_connector.go
@@ -37,6 +37,11 @@ func resourceConnector() *schema.Resource {
 				Optional:    true,
 				Description: "Whether to expose the connector as an ssh service.",
 			},
+			"built_in_ssh_service_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The socket id of the built-in ssh service.",
+			},
 		},
 	}
 }
@@ -53,10 +58,16 @@ func resourceConnectorRead(ctx context.Context, d *schema.ResourceData, m interf
 		return diagnostics.Error(err, "Failed to fetch connector")
 	}
 
+	var builtInSshServiceID string
+	if connector.BuiltInSshServiceEnabled && connector.BuiltInSshService != nil {
+		builtInSshServiceID = connector.BuiltInSshService.SocketID
+	}
+
 	return schemautil.SetValues(d, map[string]any{
 		"name":                         connector.Name,
 		"description":                  connector.Description,
 		"built_in_ssh_service_enabled": connector.BuiltInSshServiceEnabled,
+		"built_in_ssh_service_id":      builtInSshServiceID,
 	})
 }
 

--- a/border0/resource_socket.go
+++ b/border0/resource_socket.go
@@ -76,11 +76,6 @@ func resourceSocket() *schema.Resource {
 				},
 				Description: "The upstream type of the socket.",
 			},
-			"upstream_http_hostname": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "The upstream http hostname of the socket.",
-			},
 
 			"http_configuration": {
 				Type:     schema.TypeList,
@@ -93,20 +88,15 @@ func resourceSocket() *schema.Resource {
 							Default:     service.HttpServiceTypeStandard,
 							Description: "The upstream service type. Valid values: `standard`, `connector_file_server`. Defaults to `standard`.",
 						},
-						"hostname": {
+						"upstream_url": {
 							Type:        schema.TypeString,
 							Optional:    true,
-							Description: "The upstream HTTP hostname.",
-						},
-						"port": {
-							Type:        schema.TypeInt,
-							Optional:    true,
-							Description: "The upstream HTTP port number.",
+							Description: "The upstream HTTP URL. Format: `http(s)://<hostname>:<port>`. Example: `https://example.com` or `http://another.example.com:8080`. Only used when service type is `standard`.",
 						},
 						"host_header": {
 							Type:        schema.TypeString,
 							Optional:    true,
-							Description: "The upstream host header.",
+							Description: "The upstream host header. Only used when service type is `standard`, and it's different from the hostname in `upstream_url`.",
 						},
 						"file_server_directory": {
 							Type:        schema.TypeString,
@@ -372,7 +362,7 @@ func resourceSocketRead(ctx context.Context, d *schema.ResourceData, m interface
 	if diags := schemautil.FromConnector(d, connectors); diags.HasError() {
 		return diags
 	}
-	return schemautil.FromUpstreamConfig(d, upstreamConfigs)
+	return schemautil.FromUpstreamConfig(d, socket, upstreamConfigs)
 }
 
 func resourceSocketCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/docs/resources/connector.md
+++ b/docs/resources/connector.md
@@ -34,4 +34,5 @@ resource "border0_connector" "example" {
 
 ### Read-Only
 
+- `built_in_ssh_service_id` (String) The socket id of the built-in ssh service.
 - `id` (String) The ID of this resource.

--- a/docs/resources/connector_token.md
+++ b/docs/resources/connector_token.md
@@ -23,6 +23,10 @@ resource "border0_connector" "example" {
 resource "border0_connector_token" "example_token_never_expires" {
   connector_id = border0_connector.example.id
   name         = "example-connector-token-never-expires"
+
+  provisioner "local-exec" {
+    command = "echo 'token: ${self.token}' > ./border0.yaml"
+  }
 }
 
 // and create another connector token that expires at a specific date
@@ -30,6 +34,10 @@ resource "border0_connector_token" "example_token_expires" {
   connector_id = border0_connector.example.id
   name         = "example-connector-token-never-expires"
   expires_at   = "2023-12-31T23:59:59Z"
+
+  provisioner "local-exec" {
+    command = "echo 'token: ${self.token}' > ./border0.yaml"
+  }
 }
 ```
 

--- a/docs/resources/socket.md
+++ b/docs/resources/socket.md
@@ -21,11 +21,8 @@ resource "border0_socket" "example_http" {
   connector_id = border0_connector.example.id // link to a connector that was created with terraform
 
   http_configuration {
-    hostname    = "www.bbc.com"
-    port        = 443
-    host_header = "www.bbc.com"
+    upstream_url = "https://www.bbc.com"
   }
-  upstream_type = "https"
 
   tags = {
     "user"        = "Bilbo Baggins"
@@ -35,9 +32,9 @@ resource "border0_socket" "example_http" {
   }
 }
 
-// create an SSH socket and link it to a connector that's not managed by Terraform
-resource "border0_socket" "example_ssh" {
-  name              = "example-ssh"
+// create an SSH socket and link it to a connector that's not managed by terraform
+resource "border0_socket" "example_ssh_password_auth" {
+  name              = "example-ssh-password-auth"
   recording_enabled = true
   socket_type       = "ssh"
   connector_id      = "a7de4cc3-d977-4c4b-82e7-dedb6e7b74a1" // replace with your connector ID
@@ -45,14 +42,15 @@ resource "border0_socket" "example_ssh" {
   ssh_configuration {
     hostname            = "127.0.0.1"
     port                = 22
+    authentication_type = "username_and_password"
     username            = "some_user"
-    authentication_type = "border0_certificate"
+    password            = "from:file:/path/to/password/file"
   }
 }
 
-// create another SSH socket and link it to a connector that was created with Terraform
-resource "border0_socket" "example_another_ssh" {
-  name              = "example-another-ssh"
+// create another SSH socket and link it to a connector that was created with terraform
+resource "border0_socket" "example_ssh_border0_certificate_auth" {
+  name              = "example-ssh-border0-certificate-auth"
   recording_enabled = true
   socket_type       = "ssh"
   connector_id      = border0_connector.example.id // link to a connector that was created with terraform
@@ -60,13 +58,12 @@ resource "border0_socket" "example_another_ssh" {
   ssh_configuration {
     hostname            = "127.0.0.1"
     port                = 22
+    authentication_type = "border0_certificate"
     username            = "some_user"
-    password            = "some_password"
-    authentication_type = "username_and_password"
   }
 }
 
-// create a database socket and link it to a connector that was created with Terraform
+// create a database socket and link it to a connector that was created with terraform
 // this socket will be used to connect to an AWS RDS instance with IAM authentication
 // https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html
 resource "border0_socket" "example_aws_rds_with_iam_auth" {
@@ -86,7 +83,7 @@ resource "border0_socket" "example_aws_rds_with_iam_auth" {
   }
 }
 
-// create an SSH socket and link it to a connector that was created with Terraform
+// create an SSH socket and link it to a connector that was created with terraform
 // this socket will be used to connect to an AWS EC2 instance with EC2 Instance Connect
 // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-connect-set-up.html
 resource "border0_socket" "example_aws_ec2_instance_connect" {
@@ -106,7 +103,7 @@ resource "border0_socket" "example_aws_ec2_instance_connect" {
   }
 }
 
-// create an SSH socket and link it to a connector that was created with Terraform
+// create an SSH socket and link it to a connector that was created with terraform
 // this socket will be used to connect to an AWS ECS service with SSM Session Manager
 // https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html
 // https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager.html
@@ -145,7 +142,6 @@ resource "border0_socket" "example_connect_to_ecs_with_ssm" {
 - `ssh_configuration` (Block List) (see [below for nested schema](#nestedblock--ssh_configuration))
 - `tags` (Map of String) The tags of the socket.
 - `tls_configuration` (Block List) (see [below for nested schema](#nestedblock--tls_configuration))
-- `upstream_http_hostname` (String) The upstream http hostname of the socket.
 - `upstream_type` (String) The upstream type of the socket.
 
 ### Read-Only
@@ -191,10 +187,9 @@ Optional:
 Optional:
 
 - `file_server_directory` (String) The upstream file server directory. Only used when service type is `connector_file_server`.
-- `host_header` (String) The upstream host header.
-- `hostname` (String) The upstream HTTP hostname.
-- `port` (Number) The upstream HTTP port number.
+- `host_header` (String) The upstream host header. Only used when service type is `standard`, and it's different from the hostname in `upstream_url`.
 - `service_type` (String) The upstream service type. Valid values: `standard`, `connector_file_server`. Defaults to `standard`.
+- `upstream_url` (String) The upstream HTTP URL. Format: `http(s)://<hostname>:<port>`. Example: `https://example.com` or `http://another.example.com:8080`. Only used when service type is `standard`.
 
 
 <a id="nestedblock--ssh_configuration"></a>

--- a/examples/connector_and_sockets/main.tf
+++ b/examples/connector_and_sockets/main.tf
@@ -25,21 +25,20 @@ resource "border0_connector" "test_tf_connector" {
 resource "border0_connector_token" "test_tf_connector_token_never_expires" {
   connector_id = border0_connector.test_tf_connector.id
   name         = "test-tf-connector-token-never-expires"
+
+  provisioner "local-exec" {
+    command = "echo 'token: ${self.token}' > ./border0.yaml"
+  }
 }
 
 resource "border0_connector_token" "test_tf_connector_token_expires" {
   connector_id = border0_connector.test_tf_connector.id
   name         = "test-tf-connector-token-never-expires"
   expires_at   = "2023-12-31T23:59:59Z"
-}
 
-resource "border0_socket" "test_tf_http" {
-  name        = "test-tf-http"
-  socket_type = "http"
-  tags = {
-    "test_key_1" = "test_value_1"
+  provisioner "local-exec" {
+    command = "echo 'token: ${self.token}' > ./border0-connector-token-expires.yaml"
   }
-  upstream_type = "https"
 }
 
 resource "border0_socket" "test_tf_http" {
@@ -48,11 +47,8 @@ resource "border0_socket" "test_tf_http" {
   connector_id = border0_connector.test_tf_connector.id
 
   http_configuration {
-    hostname    = "www.bbc.com"
-    port        = 443
-    host_header = "www.bbc.com"
+    upstream_url = "https://www.bbc.com"
   }
-  upstream_type = "https"
 
   tags = {
     "test_key_1" = "test_value_1"

--- a/examples/development/main.tf
+++ b/examples/development/main.tf
@@ -27,7 +27,7 @@ resource "border0_connector_token" "test_tf_connector_token_never_expires" {
   name         = "test-tf-connector-token-never-expires"
 
   provisioner "local-exec" {
-    command = "echo ${self.token} > ./connector-token-never-expires"
+    command = "echo 'token: ${self.token}' > ./border0.yaml"
   }
 }
 
@@ -37,7 +37,7 @@ resource "border0_connector_token" "test_tf_connector_token_expires" {
   expires_at   = "2023-12-31T23:59:59Z"
 
   provisioner "local-exec" {
-    command = "echo ${self.token} > ./connector-token-expires"
+    command = "echo 'token: ${self.token}' > ./border0-connector-token-expires.yaml"
   }
 }
 
@@ -95,12 +95,17 @@ resource "border0_policy" "another_test_tf_policy" {
 }
 
 resource "border0_socket" "test_tf_http" {
-  name        = "test-tf-http"
-  socket_type = "http"
+  name         = "test-tf-http"
+  socket_type  = "http"
+  connector_id = border0_connector.test_tf_connector.id
+
+  http_configuration {
+    upstream_url = "https://www.bbc.com"
+  }
+
   tags = {
     "test_key_1" = "test_value_1"
   }
-  upstream_type = "https"
 }
 
 resource "border0_socket" "test_tf_ssh" {
@@ -115,6 +120,16 @@ resource "border0_socket" "test_tf_ssh" {
     username            = "test_user"
     authentication_type = "border0_certificate"
   }
+}
+
+resource "border0_policy_attachment" "test_tf_policy_builtin_ssh" {
+  policy_id = border0_policy.test_tf_policy.id
+  socket_id = border0_connector.test_tf_connector.built_in_ssh_service_id
+}
+
+resource "border0_policy_attachment" "another_test_tf_policy_builtin_ssh" {
+  policy_id = border0_policy.another_test_tf_policy.id
+  socket_id = border0_connector.test_tf_connector.built_in_ssh_service_id
 }
 
 resource "border0_policy_attachment" "test_tf_policy_http_socket" {
@@ -150,8 +165,10 @@ resource "border0_socket" "test_tf_mysql" {
 output "managed_resources" {
   value = {
     connector = {
-      id   = border0_connector.test_tf_connector.id
-      name = border0_connector.test_tf_connector.name
+      id                           = border0_connector.test_tf_connector.id
+      name                         = border0_connector.test_tf_connector.name
+      built_in_ssh_service_enabled = border0_connector.test_tf_connector.built_in_ssh_service_enabled
+      built_in_ssh_service_id      = border0_connector.test_tf_connector.built_in_ssh_service_id
     }
     connector_token = {
       id           = border0_connector_token.test_tf_connector_token_never_expires.id

--- a/examples/just_sockets/main.tf
+++ b/examples/just_sockets/main.tf
@@ -22,11 +22,8 @@ resource "border0_socket" "test_tf_http" {
   connector_id = "a7de4cc3-d977-4c4b-82e7-dedb6e7b74a1" // replace with your connector ID
 
   http_configuration {
-    hostname    = "www.bbc.com"
-    port        = 443
-    host_header = "www.bbc.com"
+    upstream_url = "https://www.bbc.com"
   }
-  upstream_type = "https"
 
   tags = {
     "test_key_1" = "test_value_1"

--- a/examples/resources/border0_connector_token/resource.tf
+++ b/examples/resources/border0_connector_token/resource.tf
@@ -8,6 +8,10 @@ resource "border0_connector" "example" {
 resource "border0_connector_token" "example_token_never_expires" {
   connector_id = border0_connector.example.id
   name         = "example-connector-token-never-expires"
+
+  provisioner "local-exec" {
+    command = "echo 'token: ${self.token}' > ./border0.yaml"
+  }
 }
 
 // and create another connector token that expires at a specific date
@@ -15,4 +19,8 @@ resource "border0_connector_token" "example_token_expires" {
   connector_id = border0_connector.example.id
   name         = "example-connector-token-never-expires"
   expires_at   = "2023-12-31T23:59:59Z"
+
+  provisioner "local-exec" {
+    command = "echo 'token: ${self.token}' > ./border0.yaml"
+  }
 }

--- a/examples/resources/border0_socket/resource.tf
+++ b/examples/resources/border0_socket/resource.tf
@@ -6,11 +6,8 @@ resource "border0_socket" "example_http" {
   connector_id = border0_connector.example.id // link to a connector that was created with terraform
 
   http_configuration {
-    hostname    = "www.bbc.com"
-    port        = 443
-    host_header = "www.bbc.com"
+    upstream_url = "https://www.bbc.com"
   }
-  upstream_type = "https"
 
   tags = {
     "user"        = "Bilbo Baggins"

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/autarch/testify v1.2.2
-	github.com/borderzero/border0-go v1.3.13
+	github.com/borderzero/border0-go v1.3.14
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/hashicorp/terraform-plugin-docs v0.16.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/autarch/testify v1.2.2 h1:9Q9V6zqhP7R6dv+zRUddv6kXKLo6ecQhnFRFWM71i1c
 github.com/autarch/testify v1.2.2/go.mod h1:oDbHKfFv2/D5UtVrxkk90OKcb6P4/AqF1Pcf6ZbvDQo=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
-github.com/borderzero/border0-go v1.3.13 h1:ov98tsV6Uk5bGoPAYIRqmomHKIOrCxKo7vADlD7kH0o=
-github.com/borderzero/border0-go v1.3.13/go.mod h1:Yll5qVCxLLICOwODQEG3O/D5Q7AtuLgbbDoj06shFaQ=
+github.com/borderzero/border0-go v1.3.14 h1:uUb09dvE2oXA2D1mcQKkTppVtKvXSKi1HO+niL/1Wtw=
+github.com/borderzero/border0-go v1.3.14/go.mod h1:Yll5qVCxLLICOwODQEG3O/D5Q7AtuLgbbDoj06shFaQ=
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/internal/schemautil/socket.go
+++ b/internal/schemautil/socket.go
@@ -14,7 +14,6 @@ import (
 // - socket_type
 // - description
 // - upstream_type
-// - upstream_http_hostname
 // - recording_enabled
 // - connector_authentication_enabled
 func FromSocket(d *schema.ResourceData, socket *border0client.Socket) diag.Diagnostics {
@@ -31,7 +30,6 @@ func FromSocket(d *schema.ResourceData, socket *border0client.Socket) diag.Diagn
 		"socket_type":                      socket.SocketType,
 		"description":                      socket.Description,
 		"upstream_type":                    socket.UpstreamType,
-		"upstream_http_hostname":           socket.UpstreamHTTPHostname,
 		"recording_enabled":                socket.RecordingEnabled,
 		"connector_authentication_enabled": socket.ConnectorAuthenticationEnabled,
 	})

--- a/internal/schemautil/socket/http/to_upstream_config.go
+++ b/internal/schemautil/socket/http/to_upstream_config.go
@@ -1,6 +1,10 @@
 package http
 
 import (
+	"regexp"
+	"strconv"
+
+	border0client "github.com/borderzero/border0-go/client"
 	"github.com/borderzero/border0-go/types/service"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -8,7 +12,7 @@ import (
 
 // ToUpstreamConfig converts a "border0_socket" resource data from "http_configuration" attribute into
 // a socket's HTTP service upstream configuration.
-func ToUpstreamConfig(d *schema.ResourceData, config *service.HttpServiceConfiguration) diag.Diagnostics {
+func ToUpstreamConfig(d *schema.ResourceData, socket *border0client.Socket, config *service.HttpServiceConfiguration) diag.Diagnostics {
 	data := make(map[string]any)
 
 	if v, ok := d.GetOk("http_configuration"); ok {
@@ -29,7 +33,7 @@ func ToUpstreamConfig(d *schema.ResourceData, config *service.HttpServiceConfigu
 		if config.StandardHttpServiceConfiguration == nil {
 			config.StandardHttpServiceConfiguration = new(service.StandardHttpServiceConfiguration)
 		}
-		return standardToUpstreamConfig(data, config.StandardHttpServiceConfiguration)
+		return standardToUpstreamConfig(data, socket, config.StandardHttpServiceConfiguration)
 
 	case service.HttpServiceTypeConnectorFileServer:
 		if config.FileServerHttpServiceConfiguration == nil {
@@ -42,15 +46,54 @@ func ToUpstreamConfig(d *schema.ResourceData, config *service.HttpServiceConfigu
 	}
 }
 
-func standardToUpstreamConfig(data map[string]any, config *service.StandardHttpServiceConfiguration) diag.Diagnostics {
-	if v, ok := data["hostname"]; ok {
-		config.Hostname = v.(string)
+func standardToUpstreamConfig(data map[string]any, socket *border0client.Socket, config *service.StandardHttpServiceConfiguration) diag.Diagnostics {
+	if v, ok := data["upstream_url"]; ok {
+		upstreamURL := v.(string)
+
+		re := regexp.MustCompile(`^(https?):\/\/([^:\/\s]+)(?::(\d+))?`)
+		matches := re.FindStringSubmatch(upstreamURL)
+
+		if len(matches) == 0 {
+			return diag.Errorf("invalid upstream URL: %s", upstreamURL)
+		}
+
+		// matches[0] is the whole string
+
+		upstreamType := matches[1]
+		hostname := matches[2]
+		port := uint16(0) // Default value
+
+		switch upstreamType {
+		case "http":
+			port = 80
+		case "https":
+			port = 443
+		default:
+			// should never happen
+		}
+
+		if len(matches) == 4 && matches[3] != "" {
+			portUint64, err := strconv.ParseUint(matches[3], 10, 16)
+			if err != nil {
+				return diag.Errorf("cannot parse port from the upstream URL: %s", upstreamURL)
+			}
+			port = uint16(portUint64)
+		}
+
+		config.Hostname = hostname
+		config.Port = port
+		config.HostHeader = hostname
+
+		// backward compatibility with the old "upstream_type" and "upstream_http_hostname" attributes
+		socket.UpstreamType = upstreamType
+		socket.UpstreamHTTPHostname = hostname
 	}
-	if v, ok := data["port"]; ok {
-		config.Port = uint16(v.(int))
-	}
+
 	if v, ok := data["host_header"]; ok {
-		config.HostHeader = v.(string)
+		hostHeader := v.(string)
+		if hostHeader != "" {
+			config.HostHeader = hostHeader
+		}
 	}
 
 	return nil

--- a/internal/schemautil/upstream_config.go
+++ b/internal/schemautil/upstream_config.go
@@ -14,8 +14,12 @@ import (
 
 // FromUpstreamConfig translates a socket's upstream service config to terraform resource data.
 // In short: *border0client.SocketUpstreamConfigs -> *schema.ResourceData
-func FromUpstreamConfig(d *schema.ResourceData, configs *border0client.SocketUpstreamConfigs) diag.Diagnostics {
-	// no-op if upstream config is not set
+func FromUpstreamConfig(
+	d *schema.ResourceData,
+	socket *border0client.Socket,
+	configs *border0client.SocketUpstreamConfigs,
+) diag.Diagnostics {
+	// noop if upstream config is not set
 	if len(configs.List) == 0 {
 		return nil
 	}
@@ -29,7 +33,7 @@ func FromUpstreamConfig(d *schema.ResourceData, configs *border0client.SocketUps
 	case service.ServiceTypeDatabase:
 		return database.FromUpstreamConfig(d, config.DatabaseServiceConfiguration)
 	case service.ServiceTypeHttp:
-		return http.FromUpstreamConfig(d, config.HttpServiceConfiguration)
+		return http.FromUpstreamConfig(d, socket, config.HttpServiceConfiguration)
 	case service.ServiceTypeTls:
 		return tls.FromUpstreamConfig(d, config.TlsServiceConfiguration)
 	default:
@@ -71,7 +75,7 @@ func ToUpstreamConfig(d *schema.ResourceData, socket *border0client.Socket) diag
 		if socket.UpstreamConfig.HttpServiceConfiguration == nil {
 			socket.UpstreamConfig.HttpServiceConfiguration = new(service.HttpServiceConfiguration)
 		}
-		diags = http.ToUpstreamConfig(d, socket.UpstreamConfig.HttpServiceConfiguration)
+		diags = http.ToUpstreamConfig(d, socket, socket.UpstreamConfig.HttpServiceConfiguration)
 
 	case service.ServiceTypeTls:
 		if socket.UpstreamConfig.TlsServiceConfiguration == nil {


### PR DESCRIPTION
Add connector managed SSH service ID to connector's computed read-only schema. The ID will be returned on connector creation if built-in SSH service is enabled.