### PR TITLE
ME-1961: fix two bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ provider "border0" {
   //
   // You can generate a Border0 access token one by going to:
   // portal.border0.com -> Organization Settings -> Access Tokens
-  // and then create a token in Admin permission groups.
+  // and then create a token in Member permission groups.
   token = "_my_access_token_"
 }
 ```

--- a/border0/provider.go
+++ b/border0/provider.go
@@ -20,7 +20,7 @@ func Provider(options ...ProviderOption) *schema.Provider {
 				Type:        schema.TypeString,
 				DefaultFunc: schema.EnvDefaultFunc("BORDER0_TOKEN", ""),
 				Required:    true,
-				Description: "The auth token used to authenticate with the Border0 API. Can also be set with the `BORDER0_TOKEN` environment variable. If you need to generate a Border0 access token, go to [Border0 Admin Portal](https://portal.border0.com) -> Organization Settings -> Access Tokens, create a token in `Admin` permission groups.",
+				Description: "The auth token used to authenticate with the Border0 API. Can also be set with the `BORDER0_TOKEN` environment variable. If you need to generate a Border0 access token, go to [Border0 Admin Portal](https://portal.border0.com) -> Organization Settings -> Access Tokens, create a token in `Member` permission groups.",
 				Sensitive:   true,
 			},
 			"api_url": {

--- a/border0/resource_connector.go
+++ b/border0/resource_connector.go
@@ -50,9 +50,10 @@ func resourceConnectorRead(ctx context.Context, d *schema.ResourceData, m interf
 	client := m.(border0client.Requester)
 	connector, err := client.Connector(ctx, d.Id())
 	if !d.IsNewResource() && border0client.NotFound(err) {
+		// in case if the connector was deleted without Terraform knowing about it, we need to remove it from the state
 		log.Printf("[WARN] Connector (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return diag.Diagnostics{}
+		return nil
 	}
 	if err != nil {
 		return diagnostics.Error(err, "Failed to fetch connector")

--- a/border0/resource_policy.go
+++ b/border0/resource_policy.go
@@ -56,9 +56,10 @@ func resourcePolicyRead(ctx context.Context, d *schema.ResourceData, m interface
 	client := m.(border0client.Requester)
 	policy, err := client.Policy(ctx, d.Id())
 	if !d.IsNewResource() && border0client.NotFound(err) {
+		// in case if the policy was deleted without Terraform knowing about it, we need to remove it from the state
 		log.Printf("[WARN] Policy (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return diag.Diagnostics{}
+		return nil
 	}
 	if err != nil {
 		return diagnostics.Error(err, "Failed to fetch policy")

--- a/border0/resource_socket_test.go
+++ b/border0/resource_socket_test.go
@@ -84,7 +84,7 @@ func Test_Resource_Border0Socket_HTTPBasic(t *testing.T) {
 
 	clientMock := mocks.APIClientRequester{}
 	mockCallsInOrder(
-		// read = client.Socket() + client.SocketConnectors() + client.SocketUpstreamConfigs()
+		// read = client.Socket() + client.Socket() + client.SocketConnectors() + client.SocketUpstreamConfigs()
 		// create = client.CreateSocket()
 		// update = client.Socket() + client.UpdateSocket()
 		// delete = client.DeleteSocket()
@@ -92,14 +92,17 @@ func Test_Resource_Border0Socket_HTTPBasic(t *testing.T) {
 		// terraform apply (create + read + read)
 		clientMock.EXPECT().CreateSocket(matchContext, &initialInput).Return(&initialOutput, nil).Call,
 		clientMock.EXPECT().Socket(matchContext, "unit-test-http-socket-id").Return(&initialOutput, nil).Call,
+		clientMock.EXPECT().Socket(matchContext, "unit-test-http-socket").Return(&initialOutput, nil).Call,
 		clientMock.EXPECT().SocketConnectors(matchContext, "unit-test-http-socket-id").Return(new(border0client.SocketConnectors), nil).Call,
 		clientMock.EXPECT().SocketUpstreamConfigs(matchContext, "unit-test-http-socket-id").Return(new(border0client.SocketUpstreamConfigs), nil).Call,
 		clientMock.EXPECT().Socket(matchContext, "unit-test-http-socket-id").Return(&initialOutput, nil).Call,
+		clientMock.EXPECT().Socket(matchContext, "unit-test-http-socket").Return(&initialOutput, nil).Call,
 		clientMock.EXPECT().SocketConnectors(matchContext, "unit-test-http-socket-id").Return(new(border0client.SocketConnectors), nil).Call,
 		clientMock.EXPECT().SocketUpstreamConfigs(matchContext, "unit-test-http-socket-id").Return(new(border0client.SocketUpstreamConfigs), nil).Call,
 
 		// this read is needed because of the update
 		clientMock.EXPECT().Socket(matchContext, "unit-test-http-socket-id").Return(&initialOutput, nil).Call,
+		clientMock.EXPECT().Socket(matchContext, "unit-test-http-socket").Return(&initialOutput, nil).Call,
 		clientMock.EXPECT().SocketConnectors(matchContext, "unit-test-http-socket-id").Return(new(border0client.SocketConnectors), nil).Call,
 		clientMock.EXPECT().SocketUpstreamConfigs(matchContext, "unit-test-http-socket-id").Return(new(border0client.SocketUpstreamConfigs), nil).Call,
 
@@ -108,14 +111,17 @@ func Test_Resource_Border0Socket_HTTPBasic(t *testing.T) {
 		clientMock.EXPECT().Socket(matchContext, "unit-test-http-socket-id").Return(&updateOutput, nil).Call,
 		clientMock.EXPECT().UpdateSocket(matchContext, "unit-test-http-socket-id", &updateInput).Return(&updateOutput, nil).Call,
 		clientMock.EXPECT().Socket(matchContext, "unit-test-http-socket-id").Return(&updateOutput, nil).Call,
+		clientMock.EXPECT().Socket(matchContext, "unit-test-http-socket").Return(&updateOutput, nil).Call,
 		clientMock.EXPECT().SocketConnectors(matchContext, "unit-test-http-socket-id").Return(new(border0client.SocketConnectors), nil).Call,
 		clientMock.EXPECT().SocketUpstreamConfigs(matchContext, "unit-test-http-socket-id").Return(new(border0client.SocketUpstreamConfigs), nil).Call,
 		clientMock.EXPECT().Socket(matchContext, "unit-test-http-socket-id").Return(&updateOutput, nil).Call,
+		clientMock.EXPECT().Socket(matchContext, "unit-test-http-socket").Return(&updateOutput, nil).Call,
 		clientMock.EXPECT().SocketConnectors(matchContext, "unit-test-http-socket-id").Return(new(border0client.SocketConnectors), nil).Call,
 		clientMock.EXPECT().SocketUpstreamConfigs(matchContext, "unit-test-http-socket-id").Return(new(border0client.SocketUpstreamConfigs), nil).Call,
 
 		// terraform import (read)
 		clientMock.EXPECT().Socket(matchContext, "unit-test-http-socket-id").Return(&updateOutput, nil).Call,
+		clientMock.EXPECT().Socket(matchContext, "unit-test-http-socket").Return(&updateOutput, nil).Call,
 		clientMock.EXPECT().SocketConnectors(matchContext, "unit-test-http-socket-id").Return(new(border0client.SocketConnectors), nil).Call,
 		clientMock.EXPECT().SocketUpstreamConfigs(matchContext, "unit-test-http-socket-id").Return(new(border0client.SocketUpstreamConfigs), nil).Call,
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ provider "border0" {
   //
   // You can generate a Border0 access token one by going to:
   // portal.border0.com -> Organization Settings -> Access Tokens
-  // and then create a token in Admin permission groups.
+  // and then create a token in Member permission groups.
   token = "_my_access_token_"
 }
 ```
@@ -38,4 +38,4 @@ provider "border0" {
 ### Optional
 
 - `api_url` (String) The URL of the Border0 API. Can also be set with the `BORDER0_API` environment variable. Defaults to `https://api.border0.com/api/v1`.
-- `token` (String, Sensitive) The auth token used to authenticate with the Border0 API. Can also be set with the `BORDER0_TOKEN` environment variable. If you need to generate a Border0 access token, go to [Border0 Admin Portal](https://portal.border0.com) -> Organization Settings -> Access Tokens, create a token in `Admin` permission groups.
+- `token` (String, Sensitive) The auth token used to authenticate with the Border0 API. Can also be set with the `BORDER0_TOKEN` environment variable. If you need to generate a Border0 access token, go to [Border0 Admin Portal](https://portal.border0.com) -> Organization Settings -> Access Tokens, create a token in `Member` permission groups.

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -12,6 +12,6 @@ provider "border0" {
   //
   // You can generate a Border0 access token one by going to:
   // portal.border0.com -> Organization Settings -> Access Tokens
-  // and then create a token in Admin permission groups.
+  // and then create a token in Member permission groups.
   token = "_my_access_token_"
 }


### PR DESCRIPTION
- if connector and connector token are created in the same config, and in a location with a slower response time, and connector token transaction doesn't get committed in time, terraform may return an error about inconsisten state
- if a terraform managed socket is deleted from portal, instead of removing it from the state and prompt to recreate the socket, it returns an error about socket does not exist