### PR TITLE
ME-2069: create connector and built-in ssh socket separately

### DIFF
--- a/border0/resource_connector_test.go
+++ b/border0/resource_connector_test.go
@@ -53,7 +53,7 @@ func Test_Resource_Border0Connector(t *testing.T) {
 		// this read is needed because of the update
 		clientMock.EXPECT().Connector(matchContext, "unit-test-id-1").Return(&initialOutput, nil).Call,
 
-		// terraform aplly (update + read + read)
+		// terraform apply (update + read + read)
 		clientMock.EXPECT().UpdateConnector(matchContext, &updateInputOutput).Return(&updateInputOutput, nil).Call,
 		clientMock.EXPECT().Connector(matchContext, "unit-test-id-1").Return(&updateInputOutput, nil).Call,
 		clientMock.EXPECT().Connector(matchContext, "unit-test-id-1").Return(&updateInputOutput, nil).Call,

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/autarch/testify v1.2.2
-	github.com/borderzero/border0-go v1.3.14
+	github.com/borderzero/border0-go v1.3.15
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/hashicorp/terraform-plugin-docs v0.16.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/autarch/testify v1.2.2 h1:9Q9V6zqhP7R6dv+zRUddv6kXKLo6ecQhnFRFWM71i1c
 github.com/autarch/testify v1.2.2/go.mod h1:oDbHKfFv2/D5UtVrxkk90OKcb6P4/AqF1Pcf6ZbvDQo=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
-github.com/borderzero/border0-go v1.3.14 h1:uUb09dvE2oXA2D1mcQKkTppVtKvXSKi1HO+niL/1Wtw=
-github.com/borderzero/border0-go v1.3.14/go.mod h1:Yll5qVCxLLICOwODQEG3O/D5Q7AtuLgbbDoj06shFaQ=
+github.com/borderzero/border0-go v1.3.15 h1:DayLxCGacaQqsLHS2nK0vIIJyttmby8nGdopDAqU0aQ=
+github.com/borderzero/border0-go v1.3.15/go.mod h1:Yll5qVCxLLICOwODQEG3O/D5Q7AtuLgbbDoj06shFaQ=
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=


### PR DESCRIPTION
Create connector and built-in ssh service separately to avoid orphaned connectors if built-in ssh service creation hits socket limit error.