### PR TITLE
ME-4829: Add HTTP headers support to HTTP socket

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ NAMESPACE=border0
 NAME=border0
 BINARY=terraform-provider-${NAME}
 VERSION=0.1.0
-OS_ARCH=darwin_arm64
+OS_ARCH?=$(shell go env GOOS)_$(shell go env GOARCH)
 
 .PHONY: install
 install: build ## Install the provider in the terraform plugins directory

--- a/border0/resource_socket.go
+++ b/border0/resource_socket.go
@@ -92,6 +92,26 @@ func resourceSocket() *schema.Resource {
 							Optional:    true,
 							Description: "The upstream host header. Only used when service type is `standard`, and it's different from the hostname in `upstream_url`.",
 						},
+						"header": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:        schema.TypeString,
+										Required:    true,
+										Description: "HTTP header name",
+									},
+									"values": {
+										Type:        schema.TypeList,
+										Required:    true,
+										Elem:        &schema.Schema{Type: schema.TypeString},
+										Description: "List of values for the header. Multiple values are supported.",
+									},
+								},
+							},
+							Description: "Custom HTTP headers forwarded to the upstream service. Each header has a key and a list of values.",
+						},
 						"file_server_directory": {
 							Type:        schema.TypeString,
 							Optional:    true,

--- a/border0/resource_user_test.go
+++ b/border0/resource_user_test.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/mock"
 	border0client "github.com/borderzero/border0-go/client"
 	"github.com/borderzero/terraform-provider-border0/mocks"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/stretchr/testify/mock"
 )
 
 func Test_Resource_Border0User(t *testing.T) {

--- a/docs/resources/socket.md
+++ b/docs/resources/socket.md
@@ -22,6 +22,14 @@ resource "border0_socket" "example_http" {
 
   http_configuration {
     upstream_url = "https://www.bbc.com"
+    header {
+      key    = "X-Custom-Header"
+      values = ["custom-value", "another-value"]
+    }
+    header {
+      key    = "X-Another-Header"
+      values = ["yet-another-value"]
+    }
   }
 
   tags = {
@@ -218,9 +226,19 @@ Optional:
 Optional:
 
 - `file_server_directory` (String) The upstream file server directory. Only used when service type is `connector_file_server`.
+- `header` (Block List) Custom HTTP headers forwarded to the upstream service. Each header has a key and a list of values. (see [below for nested schema](#nestedblock--http_configuration--header))
 - `host_header` (String) The upstream host header. Only used when service type is `standard`, and it's different from the hostname in `upstream_url`.
 - `service_type` (String) The upstream service type. Valid values: `standard`, `connector_file_server`. Defaults to `standard`.
 - `upstream_url` (String) The upstream HTTP URL. Format: `http(s)://<hostname>:<port>`. Example: `https://example.com` or `http://another.example.com:8080`. Only used when service type is `standard`.
+
+<a id="nestedblock--http_configuration--header"></a>
+### Nested Schema for `http_configuration.header`
+
+Required:
+
+- `key` (String) HTTP header name
+- `values` (List of String) List of values for the header. Multiple values are supported.
+
 
 
 <a id="nestedblock--kubernetes_configuration"></a>

--- a/examples/connector_and_sockets/main.tf
+++ b/examples/connector_and_sockets/main.tf
@@ -47,6 +47,14 @@ resource "border0_socket" "test_tf_http" {
 
   http_configuration {
     upstream_url = "https://www.bbc.com"
+    header {
+      key    = "X-Custom-Header"
+      values = ["custom-value", "another-value"]
+    }
+    header {
+      key    = "X-Another-Header"
+      values = ["yet-another-value"]
+    }
   }
 
   tags = {

--- a/examples/development/main.tf
+++ b/examples/development/main.tf
@@ -34,7 +34,7 @@ resource "border0_connector_token" "test_tf_connector_token_never_expires" {
 resource "border0_connector_token" "test_tf_connector_token_expires" {
   connector_id = border0_connector.test_tf_connector.id
   name         = "test-tf-connector-token-expires"
-  expires_at   = "2024-12-31T23:59:59Z"
+  expires_at   = "2035-12-31T23:59:59Z"
 
   provisioner "local-exec" {
     command = "echo 'token: ${self.token}' > ./border0-connector-token-expires.yaml"
@@ -112,12 +112,20 @@ resource "border0_socket" "test_tf_http" {
 
   http_configuration {
     upstream_url = "https://www.bbc.com"
+    header {
+      key    = "X-Custom-Header"
+      values = ["custom-value"]
+    }
+    header {
+      key    = "X-Another-Header"
+      values = ["another-value", "second-value"]
+    }
   }
-
   tags = {
     "test_key_1" = "test_value_1"
   }
 }
+
 
 resource "border0_socket" "test_tf_ssh" {
   name              = "test-tf-ssh"

--- a/examples/just_sockets/main.tf
+++ b/examples/just_sockets/main.tf
@@ -22,6 +22,10 @@ resource "border0_socket" "test_tf_http" {
 
   http_configuration {
     upstream_url = "https://www.bbc.com"
+    header {
+      key    = "X-Custom-Header"
+      values = ["custom-value", "another-value"]
+    }
   }
 
   tags = {

--- a/examples/resources/border0_socket/resource.tf
+++ b/examples/resources/border0_socket/resource.tf
@@ -7,6 +7,14 @@ resource "border0_socket" "example_http" {
 
   http_configuration {
     upstream_url = "https://www.bbc.com"
+    header {
+      key    = "X-Custom-Header"
+      values = ["custom-value", "another-value"]
+    }
+    header {
+      key    = "X-Another-Header"
+      values = ["yet-another-value"]
+    }
   }
 
   tags = {

--- a/internal/schemautil/socket/http/from_upstream_config.go
+++ b/internal/schemautil/socket/http/from_upstream_config.go
@@ -61,6 +61,23 @@ func standardFromUpstreamConfig(data *map[string]any, socket *border0client.Sock
 	}
 	(*data)["host_header"] = hostHeader
 
+	if len(config.Headers) > 0 {
+		headerMap := make(map[string][]string)
+		for _, header := range config.Headers {
+			if header.Key == "" || header.Value == "" {
+				continue
+			}
+			headerMap[header.Key] = append(headerMap[header.Key], header.Value)
+		}
+		var headersList []map[string]any
+		for key, values := range headerMap {
+			headersList = append(headersList, map[string]any{"key": key, "values": values})
+		}
+		if len(headersList) > 0 {
+			(*data)["header"] = headersList
+		}
+	}
+
 	return nil
 }
 

--- a/internal/schemautil/socket/http/to_upstream_config.go
+++ b/internal/schemautil/socket/http/to_upstream_config.go
@@ -96,6 +96,22 @@ func standardToUpstreamConfig(data map[string]any, socket *border0client.Socket,
 		}
 	}
 
+	var headers []service.Header
+	if v, ok := data["header"]; ok {
+		for _, h := range v.([]any) {
+			m := h.(map[string]any)
+			key := m["key"].(string)
+			var values []string
+			for _, val := range m["values"].([]any) {
+				values = append(values, val.(string))
+			}
+			for _, v := range values {
+				headers = append(headers, service.Header{Key: key, Value: v})
+			}
+		}
+		config.Headers = headers
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary
[ME-4829]  Add HTTP headers support to HTTP socket
- support custom headers in `http_configuration`
- expose header list in `resource_socket`
- document new `headers` field
- show headers in examples

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_6877afdda720832582d3d2ef0c251bf6

[ME-4829]: https://mysocket.atlassian.net/browse/ME-4829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ