### PR TITLE
[ME-4888] Suppress Equivalent Policy Diffs

### DIFF
--- a/border0/provider.go
+++ b/border0/provider.go
@@ -11,7 +11,11 @@ import (
 
 // NOTE: currently only applies to socket, but we plan on
 // having this apply to all resources using the same semaphore.
-const maxParallelism = 5
+//
+// Terraform's parallelism is 10 by default but can be set to any
+// value using the "-parallelism" flag e.g. -parallelism=200...
+// So we cap it at 100 here in case it's set to a higher value.
+const maxParallelism = 100
 
 // ProviderOption is a function that can be passed to `Provider()` to configures it.
 type ProviderOption func(p *schema.Provider)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/borderzero/terraform-provider-border0
 go 1.24
 
 require (
-	github.com/borderzero/border0-go v1.4.88
+	github.com/borderzero/border0-go v1.4.89
 	github.com/golang-jwt/jwt/v5 v5.2.3
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/terraform-plugin-docs v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/bgentry/speakeasy v0.2.0 h1:tgObeVOf8WAvtuAX6DhJ4xks4CFNwPDZiqzGqIHE5
 github.com/bgentry/speakeasy v0.2.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bmatcuk/doublestar/v4 v4.9.1 h1:X8jg9rRZmJd4yRy7ZeNDRnM+T3ZfHv15JiBJ/avrEXE=
 github.com/bmatcuk/doublestar/v4 v4.9.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
-github.com/borderzero/border0-go v1.4.88 h1:CoEjbjiZsRNcMp7tnw4vIREiSdYJx/wZJd9fuW4j92s=
-github.com/borderzero/border0-go v1.4.88/go.mod h1:ZHJou3/DK22v0iOmdsG8ImwQmGpzHjPuhwGU94DuCt0=
+github.com/borderzero/border0-go v1.4.89 h1:jdiwZF2t8hGUkv092mC6wdwlw1ZlBxN3sA3uOLCZuvI=
+github.com/borderzero/border0-go v1.4.89/go.mod h1:ZHJou3/DK22v0iOmdsG8ImwQmGpzHjPuhwGU94DuCt0=
 github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZlaQsNA=
 github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp+BagBSZWx+TP8=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=


### PR DESCRIPTION
## [[ME-4888](https://mysocket.atlassian.net/browse/ME-4888)] Suppress Equivalent Policy Diffs

- Also pins sockets max concurrency to 100 despite setting `-parallelism=${n}`.

[ME-4888]: https://mysocket.atlassian.net/browse/ME-4888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ