### PR TITLE
[ME-4906] Fix AWS Creds Parsing Ineffectual Assignment

### DIFF
--- a/internal/schemautil/socket/database/to_upstream_config.go
+++ b/internal/schemautil/socket/database/to_upstream_config.go
@@ -167,7 +167,7 @@ func awsRdsToUpstreamConfig(data map[string]any, config *service.AwsRdsDatabaseS
 			config.IamAuth.CaCertificate = v.(string)
 		}
 		if v, ok := data["aws_credentials"]; ok {
-			shared.ToAwsCredentials(v, config.IamAuth.AwsCredentials)
+			config.IamAuth.AwsCredentials = shared.ToAwsCredentials(v)
 		}
 	default:
 		return diag.Errorf(`database authentication type "%s" is invalid`, authType)
@@ -221,7 +221,7 @@ func awsDocumentDBToUpstreamConfig(data map[string]any, config *service.AwsDocum
 			config.IamAuth.CaCertificate = v.(string)
 		}
 		if v, ok := data["aws_credentials"]; ok {
-			shared.ToAwsCredentials(v, config.IamAuth.AwsCredentials)
+			config.IamAuth.AwsCredentials = shared.ToAwsCredentials(v)
 		}
 	default:
 		return diag.Errorf(`database authentication type "%s" is invalid`, authType)

--- a/internal/schemautil/socket/kubernetes/to_upstream_config.go
+++ b/internal/schemautil/socket/kubernetes/to_upstream_config.go
@@ -89,8 +89,7 @@ func awsEksToUpstreamConfig(data map[string]any, config *service.AwsEksKubernete
 		config.EksClusterRegion = v.(string)
 	}
 	if v, ok := data["aws_credentials"]; ok {
-		shared.ToAwsCredentials(v, config.AwsCredentials)
+		config.AwsCredentials = shared.ToAwsCredentials(v)
 	}
-
 	return nil
 }

--- a/internal/schemautil/socket/shared/aws_credentials.go
+++ b/internal/schemautil/socket/shared/aws_credentials.go
@@ -49,34 +49,50 @@ func FromAwsCredentials(creds *common.AwsCredentials) []map[string]any {
 	if creds == nil {
 		return nil
 	}
-	return []map[string]any{
-		{
-			"access_key_id":     creds.AwsAccessKeyId,
-			"secret_access_key": creds.AwsSecretAccessKey,
-			"session_token":     creds.AwsSessionToken,
-			"profile":           creds.AwsProfile,
-		},
+	m := make(map[string]any)
+	if creds.AwsAccessKeyId != nil && *creds.AwsAccessKeyId != "" {
+		m["access_key_id"] = creds.AwsAccessKeyId
 	}
+	if creds.AwsSecretAccessKey != nil && *creds.AwsSecretAccessKey != "" {
+		m["secret_access_key"] = creds.AwsSecretAccessKey
+	}
+	if creds.AwsSessionToken != nil && *creds.AwsSessionToken != "" {
+		m["session_token"] = creds.AwsSessionToken
+	}
+	if creds.AwsProfile != nil && *creds.AwsProfile != "" {
+		m["profile"] = creds.AwsProfile
+	}
+	return []map[string]any{m}
 }
 
 // ToAwsCredentials converts the `aws_credentials` block to a `common.AwsCredentials` struct.
-func ToAwsCredentials(v any, creds *common.AwsCredentials) {
+func ToAwsCredentials(v any) *common.AwsCredentials {
 	if awsCredentialsList := v.([]any); len(awsCredentialsList) > 0 {
 		awsCredentials := awsCredentialsList[0].(map[string]any)
-		if creds == nil {
-			creds = new(common.AwsCredentials)
-		}
+
+		creds := new(common.AwsCredentials)
+		nonEmpty := false
+
 		if v, ok := awsCredentials["access_key_id"]; ok {
 			creds.AwsAccessKeyId = pointer.To(v.(string))
+			nonEmpty = true
 		}
 		if v, ok := awsCredentials["secret_access_key"]; ok {
 			creds.AwsSecretAccessKey = pointer.To(v.(string))
+			nonEmpty = true
 		}
 		if v, ok := awsCredentials["session_token"]; ok {
 			creds.AwsSessionToken = pointer.To(v.(string))
+			nonEmpty = true
 		}
 		if v, ok := awsCredentials["profile"]; ok {
 			creds.AwsProfile = pointer.To(v.(string))
+			nonEmpty = true
+		}
+
+		if nonEmpty {
+			return creds
 		}
 	}
+	return nil
 }

--- a/internal/schemautil/socket/ssh/to_upstream_config.go
+++ b/internal/schemautil/socket/ssh/to_upstream_config.go
@@ -148,7 +148,7 @@ func awsEc2InstanceConnectToUpstreamConfig(data map[string]any, config *service.
 		config.Ec2InstanceRegion = v.(string)
 	}
 	if v, ok := data["aws_credentials"]; ok {
-		shared.ToAwsCredentials(v, config.AwsCredentials)
+		config.AwsCredentials = shared.ToAwsCredentials(v)
 	}
 
 	return nil
@@ -174,7 +174,7 @@ func awsSsmToUpstreamConfig(data map[string]any, config *service.AwsSsmSshServic
 			config.AwsSsmEc2TargetConfiguration.Ec2InstanceRegion = v.(string)
 		}
 		if v, ok := data["aws_credentials"]; ok {
-			shared.ToAwsCredentials(v, config.AwsSsmEc2TargetConfiguration.AwsCredentials)
+			config.AwsSsmEc2TargetConfiguration.AwsCredentials = shared.ToAwsCredentials(v)
 		}
 	case service.SsmTargetTypeEcs:
 		if config.AwsSsmEcsTargetConfiguration == nil {
@@ -190,7 +190,7 @@ func awsSsmToUpstreamConfig(data map[string]any, config *service.AwsSsmSshServic
 			config.AwsSsmEcsTargetConfiguration.EcsServiceName = v.(string)
 		}
 		if v, ok := data["aws_credentials"]; ok {
-			shared.ToAwsCredentials(v, config.AwsSsmEcsTargetConfiguration.AwsCredentials)
+			config.AwsSsmEcsTargetConfiguration.AwsCredentials = shared.ToAwsCredentials(v)
 		}
 	default:
 		return diag.Errorf(`ssm target type "%s" is invalid`, targetType)


### PR DESCRIPTION
## [[ME-4906](https://mysocket.atlassian.net/browse/ME-4906)] Fix AWS Creds Parsing Ineffectual Assignment

Parser is currently modifying a local variable, not the actual object passed as an argument.


[ME-4906]: https://mysocket.atlassian.net/browse/ME-4906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ