### PR TITLE
[ME-4907] Minor Misc Improvements, Deprecation Message

### DIFF
--- a/border0/data_source_group_names_to_ids.go
+++ b/border0/data_source_group_names_to_ids.go
@@ -38,7 +38,7 @@ func dataSourceGroupNamesToIDs() *schema.Resource {
 	}
 }
 
-func dataSourceGroupNamesToIDsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func dataSourceGroupNamesToIDsRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := m.(border0client.Requester)
 
 	groups := set.New[string]()

--- a/border0/data_source_policy_document.go
+++ b/border0/data_source_policy_document.go
@@ -13,10 +13,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+// deprecated in favor of dataSourcePolicyV2Document, see DeprecationMessage for more info.
 func dataSourcePolicyDocument() *schema.Resource {
 	return &schema.Resource{
-		Description: "`border0_policy_document` data source can be used to generate a policy document in JSON format for use with `border0_policy` resource.",
-		ReadContext: dataSourcePolicyDocumentRead,
+		DeprecationMessage: "`border0_policy_document` is deprecated. Use `border0_policy_v2_document` instead. The Border0 API will reject the creation of policies with v1 format and only allows updating existing v1 policies.",
+		Description:        "`border0_policy_document` data source can be used to generate a policy document in JSON format for use with `border0_policy` resource.",
+		ReadContext:        dataSourcePolicyDocumentRead,
 		Schema: map[string]*schema.Schema{
 			"json": {
 				Type:     schema.TypeString,
@@ -135,7 +137,7 @@ func dataSourcePolicyDocument() *schema.Resource {
 	}
 }
 
-func dataSourcePolicyDocumentRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func dataSourcePolicyDocumentRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	var policyData border0client.PolicyData
 
 	if v, ok := d.GetOk("action"); ok {
@@ -143,10 +145,10 @@ func dataSourcePolicyDocumentRead(ctx context.Context, d *schema.ResourceData, m
 	}
 	if v, ok := d.GetOk("condition"); ok {
 		if conditions := v.(*schema.Set).List(); len(conditions) > 0 {
-			condition := conditions[0].(map[string]interface{})
+			condition := conditions[0].(map[string]any)
 			if v, ok := condition["who"]; ok {
 				if whos := v.(*schema.Set).List(); len(whos) > 0 {
-					who := whos[0].(map[string]interface{})
+					who := whos[0].(map[string]any)
 					if v, ok := who["email"]; ok {
 						policyData.Condition.Who.Email = policyDecodeStringList(v.(*schema.Set).List())
 					}
@@ -163,7 +165,7 @@ func dataSourcePolicyDocumentRead(ctx context.Context, d *schema.ResourceData, m
 			}
 			if v, ok := condition["where"]; ok {
 				if wheres := v.(*schema.Set).List(); len(wheres) > 0 {
-					where := wheres[0].(map[string]interface{})
+					where := wheres[0].(map[string]any)
 					if v, ok := where["allowed_ip"]; ok {
 						policyData.Condition.Where.AllowedIP = policyDecodeStringList(v.(*schema.Set).List())
 					}
@@ -177,7 +179,7 @@ func dataSourcePolicyDocumentRead(ctx context.Context, d *schema.ResourceData, m
 			}
 			if v, ok := condition["when"]; ok {
 				if whens := v.(*schema.Set).List(); len(whens) > 0 {
-					when := whens[0].(map[string]interface{})
+					when := whens[0].(map[string]any)
 					if v, ok := when["after"]; ok {
 						policyData.Condition.When.After = v.(string)
 					}
@@ -206,7 +208,7 @@ func dataSourcePolicyDocumentRead(ctx context.Context, d *schema.ResourceData, m
 	return nil
 }
 
-func policyDecodeStringList(list []interface{}) []string {
+func policyDecodeStringList(list []any) []string {
 	ret := make([]string, len(list))
 	for i, value := range list {
 		ret[i] = value.(string)

--- a/border0/data_source_policy_v2_document.go
+++ b/border0/data_source_policy_v2_document.go
@@ -458,12 +458,12 @@ func dataSourcePolicyV2Document() *schema.Resource {
 	}
 }
 
-func dataSourcePolicyV2DocumentRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func dataSourcePolicyV2DocumentRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	var policyData border0client.PolicyDataV2
 
 	if v, ok := d.GetOk("permissions"); ok {
 		if permissions := v.(*schema.Set).List(); len(permissions) > 0 {
-			permMap := permissions[0].(map[string]interface{})
+			permMap := permissions[0].(map[string]any)
 
 			if v, ok := permMap["database"]; ok {
 				policyData.Permissions.Database = parseDatabasePermissions(v.(*schema.Set).List())
@@ -473,7 +473,7 @@ func dataSourcePolicyV2DocumentRead(ctx context.Context, d *schema.ResourceData,
 			}
 			if v, ok := permMap["http"]; ok {
 				if httpPerms := v.(*schema.Set).List(); len(httpPerms) > 0 {
-					httpPerm := httpPerms[0].(map[string]interface{})
+					httpPerm := httpPerms[0].(map[string]any)
 					if v, ok := httpPerm["allowed"]; ok {
 						if allowed, ok := v.(bool); ok && allowed {
 							policyData.Permissions.HTTP = &border0client.HTTPPermissions{}
@@ -483,7 +483,7 @@ func dataSourcePolicyV2DocumentRead(ctx context.Context, d *schema.ResourceData,
 			}
 			if v, ok := permMap["kubernetes"]; ok {
 				if kubernetesPerms := v.(*schema.Set).List(); len(kubernetesPerms) > 0 {
-					kubernetesPerm := kubernetesPerms[0].(map[string]interface{})
+					kubernetesPerm := kubernetesPerms[0].(map[string]any)
 					if v, ok := kubernetesPerm["allowed"]; ok {
 						if allowed, ok := v.(bool); ok && allowed {
 							policyData.Permissions.Kubernetes = &border0client.KubernetesPermissions{}
@@ -493,7 +493,7 @@ func dataSourcePolicyV2DocumentRead(ctx context.Context, d *schema.ResourceData,
 			}
 			if v, ok := permMap["tls"]; ok {
 				if tlsPerms := v.(*schema.Set).List(); len(tlsPerms) > 0 {
-					tlsPerm := tlsPerms[0].(map[string]interface{})
+					tlsPerm := tlsPerms[0].(map[string]any)
 					if v, ok := tlsPerm["allowed"]; ok {
 						if allowed, ok := v.(bool); ok && allowed {
 							policyData.Permissions.TLS = &border0client.TLSPermissions{}
@@ -503,7 +503,7 @@ func dataSourcePolicyV2DocumentRead(ctx context.Context, d *schema.ResourceData,
 			}
 			if v, ok := permMap["vnc"]; ok {
 				if vncPerms := v.(*schema.Set).List(); len(vncPerms) > 0 {
-					vncPerm := vncPerms[0].(map[string]interface{})
+					vncPerm := vncPerms[0].(map[string]any)
 					if v, ok := vncPerm["allowed"]; ok {
 						if allowed, ok := v.(bool); ok && allowed {
 							policyData.Permissions.VNC = &border0client.VNCPermissions{}
@@ -513,7 +513,7 @@ func dataSourcePolicyV2DocumentRead(ctx context.Context, d *schema.ResourceData,
 			}
 			if v, ok := permMap["rdp"]; ok {
 				if rdpPerms := v.(*schema.Set).List(); len(rdpPerms) > 0 {
-					rdpPerm := rdpPerms[0].(map[string]interface{})
+					rdpPerm := rdpPerms[0].(map[string]any)
 					if v, ok := rdpPerm["allowed"]; ok {
 						if allowed, ok := v.(bool); ok && allowed {
 							policyData.Permissions.RDP = &border0client.RDPPermissions{}
@@ -523,7 +523,7 @@ func dataSourcePolicyV2DocumentRead(ctx context.Context, d *schema.ResourceData,
 			}
 			if v, ok := permMap["network"]; ok {
 				if networkPerms := v.(*schema.Set).List(); len(networkPerms) > 0 {
-					networkPerm := networkPerms[0].(map[string]interface{})
+					networkPerm := networkPerms[0].(map[string]any)
 					if v, ok := networkPerm["allowed"]; ok {
 						if allowed, ok := v.(bool); ok && allowed {
 							policyData.Permissions.Network = &border0client.NetworkPermissions{}
@@ -536,10 +536,10 @@ func dataSourcePolicyV2DocumentRead(ctx context.Context, d *schema.ResourceData,
 
 	if v, ok := d.GetOk("condition"); ok {
 		if conditions := v.(*schema.Set).List(); len(conditions) > 0 {
-			condition := conditions[0].(map[string]interface{})
+			condition := conditions[0].(map[string]any)
 			if v, ok := condition["who"]; ok {
 				if whos := v.(*schema.Set).List(); len(whos) > 0 {
-					who := whos[0].(map[string]interface{})
+					who := whos[0].(map[string]any)
 					if v, ok := who["email"]; ok {
 						policyData.Condition.Who.Email = policyDecodeStringList(v.(*schema.Set).List())
 					}
@@ -553,7 +553,7 @@ func dataSourcePolicyV2DocumentRead(ctx context.Context, d *schema.ResourceData,
 			}
 			if v, ok := condition["where"]; ok {
 				if wheres := v.(*schema.Set).List(); len(wheres) > 0 {
-					where := wheres[0].(map[string]interface{})
+					where := wheres[0].(map[string]any)
 					if v, ok := where["allowed_ip"]; ok {
 						policyData.Condition.Where.AllowedIP = policyDecodeStringList(v.(*schema.Set).List())
 					}
@@ -567,7 +567,7 @@ func dataSourcePolicyV2DocumentRead(ctx context.Context, d *schema.ResourceData,
 			}
 			if v, ok := condition["when"]; ok {
 				if whens := v.(*schema.Set).List(); len(whens) > 0 {
-					when := whens[0].(map[string]interface{})
+					when := whens[0].(map[string]any)
 					if v, ok := when["after"]; ok {
 						policyData.Condition.When.After = v.(string)
 					}
@@ -596,13 +596,13 @@ func dataSourcePolicyV2DocumentRead(ctx context.Context, d *schema.ResourceData,
 	return nil
 }
 
-func parseDatabasePermissions(dbPerms []interface{}) *border0client.DatabasePermissions {
+func parseDatabasePermissions(dbPerms []any) *border0client.DatabasePermissions {
 	var maxSessionDurationSeconds *int
 	var allowedDatabases *[]border0client.DatabasePermission
 	var allowed bool
 
 	for _, dbPerm := range dbPerms {
-		permMap := dbPerm.(map[string]interface{})
+		permMap := dbPerm.(map[string]any)
 
 		if v, ok := permMap["allowed"]; ok {
 			allowed = v.(bool)
@@ -612,8 +612,8 @@ func parseDatabasePermissions(dbPerms []interface{}) *border0client.DatabasePerm
 			if useAllowedDatabasesList, ok := v.(bool); ok && useAllowedDatabasesList {
 				if v, ok := permMap["allowed_databases"]; ok {
 					databases := []border0client.DatabasePermission{}
-					for _, ad := range v.([]interface{}) {
-						adMap := ad.(map[string]interface{})
+					for _, ad := range v.([]any) {
+						adMap := ad.(map[string]any)
 						allowedDatabase := border0client.DatabasePermission{
 							Database: adMap["database"].(string),
 						}
@@ -622,7 +622,7 @@ func parseDatabasePermissions(dbPerms []interface{}) *border0client.DatabasePerm
 							if useAllowedQueryTypesList, ok := aql.(bool); ok && useAllowedQueryTypesList {
 								if aq, ok := adMap["allowed_query_types"]; ok {
 									queryTypes := []string{}
-									for _, qt := range aq.([]interface{}) {
+									for _, qt := range aq.([]any) {
 										queryTypes = append(queryTypes, qt.(string))
 									}
 									allowedDatabase.AllowedQueryTypes = &queryTypes
@@ -655,7 +655,7 @@ func parseDatabasePermissions(dbPerms []interface{}) *border0client.DatabasePerm
 	}
 }
 
-func parseSSHPermissions(sshPerms []interface{}) *border0client.SSHPermissions {
+func parseSSHPermissions(sshPerms []any) *border0client.SSHPermissions {
 	var shellPermission *border0client.SSHShellPermission
 	var execPermission *border0client.SSHExecPermission
 	var sftpPermission *border0client.SSHSFTPPermission
@@ -667,7 +667,7 @@ func parseSSHPermissions(sshPerms []interface{}) *border0client.SSHPermissions {
 	var allowed bool
 
 	for _, sshPerm := range sshPerms {
-		permMap := sshPerm.(map[string]interface{})
+		permMap := sshPerm.(map[string]any)
 		if v, ok := permMap["allowed"]; ok {
 			allowed = v.(bool)
 		}
@@ -675,7 +675,7 @@ func parseSSHPermissions(sshPerms []interface{}) *border0client.SSHPermissions {
 		if v, ok := permMap["shell"]; ok {
 			var execAllowed bool
 			if shells := v.(*schema.Set).List(); len(shells) > 0 {
-				shell := shells[0].(map[string]interface{})
+				shell := shells[0].(map[string]any)
 				if v, ok := shell["allowed"]; ok {
 					execAllowed, _ = v.(bool)
 				}
@@ -691,7 +691,7 @@ func parseSSHPermissions(sshPerms []interface{}) *border0client.SSHPermissions {
 			var commands []string
 
 			if execs := v.(*schema.Set).List(); len(execs) > 0 {
-				exec := execs[0].(map[string]interface{})
+				exec := execs[0].(map[string]any)
 				if v, ok := exec["allowed"]; ok {
 					execAllowed, _ = v.(bool)
 				}
@@ -701,7 +701,7 @@ func parseSSHPermissions(sshPerms []interface{}) *border0client.SSHPermissions {
 				}
 
 				if v, ok := exec["commands"]; ok {
-					for _, cmd := range v.([]interface{}) {
+					for _, cmd := range v.([]any) {
 						commands = append(commands, cmd.(string))
 					}
 				}
@@ -719,7 +719,7 @@ func parseSSHPermissions(sshPerms []interface{}) *border0client.SSHPermissions {
 		if v, ok := permMap["sftp"]; ok {
 			var sftpAllowed bool
 			if sftps := v.(*schema.Set).List(); len(sftps) > 0 {
-				sftp := sftps[0].(map[string]interface{})
+				sftp := sftps[0].(map[string]any)
 				if v, ok := sftp["allowed"]; ok {
 					sftpAllowed, _ = v.(bool)
 				}
@@ -734,7 +734,7 @@ func parseSSHPermissions(sshPerms []interface{}) *border0client.SSHPermissions {
 			var tcpForwardingAllowed, useAllowedConnectionsList bool
 			var allowedConnections *[]border0client.SSHTcpForwardingConnection
 			if tcpForwardings := v.(*schema.Set).List(); len(tcpForwardings) > 0 {
-				tcpForwarding := tcpForwardings[0].(map[string]interface{})
+				tcpForwarding := tcpForwardings[0].(map[string]any)
 				if v, ok := tcpForwarding["allowed"]; ok {
 					tcpForwardingAllowed, _ = v.(bool)
 				}
@@ -744,7 +744,7 @@ func parseSSHPermissions(sshPerms []interface{}) *border0client.SSHPermissions {
 				}
 
 				if v, ok := tcpForwarding["allowed_connections"]; ok {
-					allowedConnections = parseSSHTCPForwardingConnections(v.([]interface{}))
+					allowedConnections = parseSSHTCPForwardingConnections(v.([]any))
 				}
 
 				if tcpForwardingAllowed {
@@ -761,7 +761,7 @@ func parseSSHPermissions(sshPerms []interface{}) *border0client.SSHPermissions {
 			var kubectlExecAllowed, useAllowedNamespacesList bool
 			var allowedNamespaces *[]border0client.KubectlExecNamespace
 			if kubectlExecs := v.(*schema.Set).List(); len(kubectlExecs) > 0 {
-				kubectlExec := kubectlExecs[0].(map[string]interface{})
+				kubectlExec := kubectlExecs[0].(map[string]any)
 				if v, ok := kubectlExec["allowed"]; ok {
 					kubectlExecAllowed, _ = v.(bool)
 				}
@@ -771,7 +771,7 @@ func parseSSHPermissions(sshPerms []interface{}) *border0client.SSHPermissions {
 				}
 
 				if v, ok := kubectlExec["allowed_namespaces"]; ok {
-					allowedNamespaces = parseSSHKubectlExecNamespaces(v.([]interface{}))
+					allowedNamespaces = parseSSHKubectlExecNamespaces(v.([]any))
 				}
 
 				if kubectlExecAllowed {
@@ -788,7 +788,7 @@ func parseSSHPermissions(sshPerms []interface{}) *border0client.SSHPermissions {
 			var dockerExecAllowed, useAllowedContainerList bool
 			var allowedContainers []string
 			if dockerExecs := v.(*schema.Set).List(); len(dockerExecs) > 0 {
-				dockerExec := dockerExecs[0].(map[string]interface{})
+				dockerExec := dockerExecs[0].(map[string]any)
 				if v, ok := dockerExec["allowed"]; ok {
 					dockerExecAllowed, _ = v.(bool)
 				}
@@ -798,7 +798,7 @@ func parseSSHPermissions(sshPerms []interface{}) *border0client.SSHPermissions {
 				}
 
 				if v, ok := dockerExec["allowed_containers"]; ok {
-					for _, cmd := range v.([]interface{}) {
+					for _, cmd := range v.([]any) {
 						allowedContainers = append(allowedContainers, cmd.(string))
 					}
 				}
@@ -824,7 +824,7 @@ func parseSSHPermissions(sshPerms []interface{}) *border0client.SSHPermissions {
 			if useAllowedUsernamesList, ok := v.(bool); ok && useAllowedUsernamesList {
 				if v, ok := permMap["allowed_usernames"]; ok {
 					usernames := []string{}
-					for _, username := range v.([]interface{}) {
+					for _, username := range v.([]any) {
 						usernames = append(usernames, username.(string))
 					}
 					allowedUsernames = &usernames
@@ -849,11 +849,11 @@ func parseSSHPermissions(sshPerms []interface{}) *border0client.SSHPermissions {
 	}
 }
 
-func parseSSHTCPForwardingConnections(allowedConnections []interface{}) *[]border0client.SSHTcpForwardingConnection {
+func parseSSHTCPForwardingConnections(allowedConnections []any) *[]border0client.SSHTcpForwardingConnection {
 	var connections []border0client.SSHTcpForwardingConnection
 
 	for _, conn := range allowedConnections {
-		connMap := conn.(map[string]interface{})
+		connMap := conn.(map[string]any)
 
 		var destAddress, destPort string
 		if addr, ok := connMap["destination_address"]; ok && addr != nil {
@@ -873,11 +873,11 @@ func parseSSHTCPForwardingConnections(allowedConnections []interface{}) *[]borde
 	return &connections
 }
 
-func parseSSHKubectlExecNamespaces(allowedNamespaces []interface{}) *[]border0client.KubectlExecNamespace {
+func parseSSHKubectlExecNamespaces(allowedNamespaces []any) *[]border0client.KubectlExecNamespace {
 	var namespaces []border0client.KubectlExecNamespace
 
 	for _, ns := range allowedNamespaces {
-		nsMap := ns.(map[string]interface{})
+		nsMap := ns.(map[string]any)
 		namespace := border0client.KubectlExecNamespace{
 			Namespace: nsMap["namespace"].(string),
 		}
@@ -886,7 +886,7 @@ func parseSSHKubectlExecNamespaces(allowedNamespaces []interface{}) *[]border0cl
 			if usePodSelector, ok := ps.(bool); ok && usePodSelector {
 				if ps, ok := nsMap["pod_selector"]; ok {
 					podSelector := map[string]string{}
-					for key, value := range ps.(map[string]interface{}) {
+					for key, value := range ps.(map[string]any) {
 						podSelector[key] = value.(string)
 					}
 					namespace.PodSelector = &podSelector

--- a/border0/data_source_user_emails_to_ids.go
+++ b/border0/data_source_user_emails_to_ids.go
@@ -38,7 +38,7 @@ func dataSourceUserEmailsToIDs() *schema.Resource {
 	}
 }
 
-func dataSourceUserEmailsToIDsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func dataSourceUserEmailsToIDsRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := m.(border0client.Requester)
 
 	emails := set.New[string]()

--- a/border0/provider.go
+++ b/border0/provider.go
@@ -15,9 +15,9 @@ const (
 	// having this apply to all resources using the same semaphore.
 	//
 	// Terraform's parallelism is 10 by default but can be set to any
-	// value using the "-parallelism" flag e.g. -parallelism=200...
-	// So we cap it at 100 here in case it's set to a higher value.
-	maxParallelism = 100
+	// value using the "-parallelism" flag e.g. -parallelism=10...
+	// So we cap it at 10 here in case it's set to a higher value.
+	maxParallelism = 10
 
 	defaultTimeout = time.Second * 30
 )
@@ -54,7 +54,7 @@ func Provider(options ...ProviderOption) *schema.Provider {
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"border0_socket":                resourceSocket(semaphore),
-			"border0_policy":                resourcePolicy(),
+			"border0_policy":                resourcePolicy(semaphore),
 			"border0_policy_attachment":     resourcePolicyAttachment(),
 			"border0_connector":             resourceConnector(),
 			"border0_connector_token":       resourceConnectorToken(),
@@ -64,10 +64,12 @@ func Provider(options ...ProviderOption) *schema.Provider {
 			"border0_service_account_token": resourceServiceAccountToken(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"border0_policy_document":    dataSourcePolicyDocument(),
 			"border0_policy_v2_document": dataSourcePolicyV2Document(),
 			"border0_user_emails_to_ids": dataSourceUserEmailsToIDs(),
 			"border0_group_names_to_ids": dataSourceGroupNamesToIDs(),
+
+			// deprecated
+			"border0_policy_document": dataSourcePolicyDocument(),
 		},
 	}
 

--- a/border0/provider_test.go
+++ b/border0/provider_test.go
@@ -45,7 +45,7 @@ func testProviderFactories(t *testing.T, api border0client.Requester) map[string
 	return map[string]func() (*schema.Provider, error){
 		"border0": func() (*schema.Provider, error) {
 			return border0.Provider(func(p *schema.Provider) {
-				p.ConfigureContextFunc = func(ctx context.Context, data *schema.ResourceData) (interface{}, diag.Diagnostics) {
+				p.ConfigureContextFunc = func(ctx context.Context, data *schema.ResourceData) (any, diag.Diagnostics) {
 					return api, nil
 				}
 				p.Schema = nil // no need to include any of the global configuration

--- a/border0/resource_connector.go
+++ b/border0/resource_connector.go
@@ -46,7 +46,7 @@ func resourceConnector() *schema.Resource {
 	}
 }
 
-func resourceConnectorRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceConnectorRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := m.(border0client.Requester)
 	connector, err := client.Connector(ctx, d.Id())
 	if !d.IsNewResource() && border0client.NotFound(err) {
@@ -72,7 +72,7 @@ func resourceConnectorRead(ctx context.Context, d *schema.ResourceData, m interf
 	})
 }
 
-func resourceConnectorCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceConnectorCreate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := m.(border0client.Requester)
 	connector := &border0client.Connector{
 		Name: d.Get("name").(string),
@@ -114,7 +114,7 @@ func resourceConnectorCreate(ctx context.Context, d *schema.ResourceData, m inte
 	return nil
 }
 
-func resourceConnectorUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceConnectorUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := m.(border0client.Requester)
 
 	fieldsToCheckForChanges := []string{
@@ -146,7 +146,7 @@ func resourceConnectorUpdate(ctx context.Context, d *schema.ResourceData, m inte
 	return resourceConnectorRead(ctx, d, m)
 }
 
-func resourceConnectorDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceConnectorDelete(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := m.(border0client.Requester)
 	if err := client.DeleteConnector(ctx, d.Id()); err != nil {
 		return diagnostics.Error(err, "Failed to delete connector")

--- a/border0/resource_connector_token.go
+++ b/border0/resource_connector_token.go
@@ -49,7 +49,7 @@ func resourceConnectorToken() *schema.Resource {
 	}
 }
 
-func resourceConnectorTokenRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceConnectorTokenRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := m.(border0client.Requester)
 
 	var connectorID, connectorTokenID string
@@ -78,7 +78,7 @@ func resourceConnectorTokenRead(ctx context.Context, d *schema.ResourceData, m i
 	})
 }
 
-func resourceConnectorTokenCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceConnectorTokenCreate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := m.(border0client.Requester)
 	connectorID := d.Get("connector_id").(string)
 	connectorToken := &border0client.ConnectorToken{
@@ -110,7 +110,7 @@ func resourceConnectorTokenCreate(ctx context.Context, d *schema.ResourceData, m
 	return resourceConnectorTokenRead(ctx, d, m)
 }
 
-func resourceConnectorTokenDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceConnectorTokenDelete(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := m.(border0client.Requester)
 
 	var connectorID, connectorTokenID string

--- a/border0/resource_group.go
+++ b/border0/resource_group.go
@@ -42,7 +42,7 @@ func resourceGroup() *schema.Resource {
 	}
 }
 
-func resourceGroupRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceGroupRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := m.(border0client.Requester)
 
 	group, err := client.Group(ctx, d.Id())
@@ -62,7 +62,7 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, m interface{
 	})
 }
 
-func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := m.(border0client.Requester)
 
 	group := &border0client.Group{
@@ -101,7 +101,7 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, m interfac
 	return nil
 }
 
-func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := m.(border0client.Requester)
 
 	group := &border0client.Group{
@@ -133,7 +133,7 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, m interfac
 	return resourceGroupRead(ctx, d, m)
 }
 
-func resourceGroupDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceGroupDelete(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := m.(border0client.Requester)
 	if err := client.DeleteGroup(ctx, d.Id()); err != nil {
 		return diagnostics.Error(err, "Failed to delete group")

--- a/border0/resource_policy_attachment.go
+++ b/border0/resource_policy_attachment.go
@@ -39,7 +39,7 @@ func resourcePolicyAttachment() *schema.Resource {
 	}
 }
 
-func resourcePolicyAttachmentRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourcePolicyAttachmentRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := m.(border0client.Requester)
 
 	ids := strings.Split(d.Id(), ":")
@@ -70,7 +70,7 @@ func resourcePolicyAttachmentRead(ctx context.Context, d *schema.ResourceData, m
 	return nil
 }
 
-func resourcePolicyAttachmentCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourcePolicyAttachmentCreate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := m.(border0client.Requester)
 	policyID := d.Get("policy_id").(string)
 	socketID := d.Get("socket_id").(string)
@@ -82,7 +82,7 @@ func resourcePolicyAttachmentCreate(ctx context.Context, d *schema.ResourceData,
 	return resourcePolicyAttachmentRead(ctx, d, m)
 }
 
-func resourcePolicyAttachmentDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourcePolicyAttachmentDelete(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := m.(border0client.Requester)
 	ids := strings.Split(d.Id(), ":")
 	if len(ids) != 2 {

--- a/border0/resource_policy_test.go
+++ b/border0/resource_policy_test.go
@@ -673,7 +673,7 @@ resource "border0_policy" "unit_test_tags" {
 	})
 }
 
-func toJSON(v interface{}) string {
+func toJSON(v any) string {
 	b, _ := json.Marshal(v)
 	return string(b)
 }

--- a/border0/resource_service_account.go
+++ b/border0/resource_service_account.go
@@ -47,7 +47,7 @@ func resourceServiceAccount() *schema.Resource {
 	}
 }
 
-func resourceServiceAccountRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServiceAccountRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := m.(border0client.Requester)
 
 	serviceAccount, err := client.ServiceAccount(ctx, d.Id())
@@ -69,7 +69,7 @@ func resourceServiceAccountRead(ctx context.Context, d *schema.ResourceData, m i
 	})
 }
 
-func resourceServiceAccountCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServiceAccountCreate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := m.(border0client.Requester)
 
 	serviceAccount := &border0client.ServiceAccount{
@@ -95,7 +95,7 @@ func resourceServiceAccountCreate(ctx context.Context, d *schema.ResourceData, m
 	return nil
 }
 
-func resourceServiceAccountUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServiceAccountUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := m.(border0client.Requester)
 
 	fieldsToCheckForChanges := []string{
@@ -121,7 +121,7 @@ func resourceServiceAccountUpdate(ctx context.Context, d *schema.ResourceData, m
 	return resourceServiceAccountRead(ctx, d, m)
 }
 
-func resourceServiceAccountDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServiceAccountDelete(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := m.(border0client.Requester)
 	if err := client.DeleteServiceAccount(ctx, d.Get("name").(string)); err != nil {
 		return diagnostics.Error(err, "Failed to delete service account")

--- a/border0/resource_service_account_token.go
+++ b/border0/resource_service_account_token.go
@@ -49,7 +49,7 @@ func resourceServiceAccountToken() *schema.Resource {
 	}
 }
 
-func resourceServiceAccountTokenRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServiceAccountTokenRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := m.(border0client.Requester)
 
 	var serviceAccountTokenID, serviceAccountName string
@@ -84,7 +84,7 @@ func resourceServiceAccountTokenRead(ctx context.Context, d *schema.ResourceData
 	return nil
 }
 
-func resourceServiceAccountTokenCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServiceAccountTokenCreate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := m.(border0client.Requester)
 
 	serviceAccountName := d.Get("service_account_name").(string)
@@ -118,7 +118,7 @@ func resourceServiceAccountTokenCreate(ctx context.Context, d *schema.ResourceDa
 	return resourceServiceAccountTokenRead(ctx, d, m)
 }
 
-func resourceServiceAccountTokenDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServiceAccountTokenDelete(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := m.(border0client.Requester)
 
 	var serviceAccountTokenID, serviceAccountName string

--- a/border0/resource_socket.go
+++ b/border0/resource_socket.go
@@ -602,7 +602,7 @@ func resourceSocket(semaphore sem.Semaphore) *schema.Resource {
 	}
 }
 
-func resourceSocketRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSocketRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := m.(border0client.Requester)
 
 	socket, diags := fetchSocket(ctx, d, m, d.Id())
@@ -634,7 +634,7 @@ func resourceSocketRead(ctx context.Context, d *schema.ResourceData, m interface
 	return schemautil.FromUpstreamConfig(d, socket, upstreamConfigs)
 }
 
-func fetchSocket(ctx context.Context, d *schema.ResourceData, m interface{}, idOrName string) (*border0client.Socket, diag.Diagnostics) {
+func fetchSocket(ctx context.Context, d *schema.ResourceData, m any, idOrName string) (*border0client.Socket, diag.Diagnostics) {
 	client := m.(border0client.Requester)
 
 	// get socket by id or by name
@@ -654,7 +654,7 @@ func fetchSocket(ctx context.Context, d *schema.ResourceData, m interface{}, idO
 }
 
 func getResourceSocketCreate(sem sem.Semaphore) schema.CreateContextFunc {
-	return func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	return func(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 		sem.Acquire()
 		defer sem.Release()
 
@@ -683,7 +683,7 @@ func getResourceSocketCreate(sem sem.Semaphore) schema.CreateContextFunc {
 }
 
 func getResourceSocketUpdate(sem sem.Semaphore) schema.UpdateContextFunc {
-	return func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	return func(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 		sem.Acquire()
 		defer sem.Release()
 
@@ -718,7 +718,7 @@ func getResourceSocketUpdate(sem sem.Semaphore) schema.UpdateContextFunc {
 }
 
 func getResourceSocketDelete(sem sem.Semaphore) schema.DeleteContextFunc {
-	return func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	return func(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 		sem.Acquire()
 		defer sem.Release()
 

--- a/border0/resource_user.go
+++ b/border0/resource_user.go
@@ -47,7 +47,7 @@ func resourceUser() *schema.Resource {
 	}
 }
 
-func resourceUserRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceUserRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := m.(border0client.Requester)
 
 	user, err := client.User(ctx, d.Id())
@@ -69,7 +69,7 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, m interface{}
 	})
 }
 
-func resourceUserCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceUserCreate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := m.(border0client.Requester)
 
 	user := &border0client.User{
@@ -102,7 +102,7 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, m interface
 	return nil
 }
 
-func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := m.(border0client.Requester)
 
 	fieldsToCheckForChanges := []string{
@@ -128,7 +128,7 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, m interface
 	return resourceUserRead(ctx, d, m)
 }
 
-func resourceUserDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceUserDelete(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := m.(border0client.Requester)
 	if err := client.DeleteUser(ctx, d.Id()); err != nil {
 		return diagnostics.Error(err, "Failed to delete user")

--- a/internal/diagnostics/error.go
+++ b/internal/diagnostics/error.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Error returns a diag.Diagnostics with the given error message and severity.
-func Error(err error, message string, args ...interface{}) diag.Diagnostics {
+func Error(err error, message string, args ...any) diag.Diagnostics {
 	var detail string
 	if err != nil {
 		detail = err.Error()


### PR DESCRIPTION
## [[ME-4907](https://mysocket.atlassian.net/browse/ME-4907)] Minor Misc Improvements, Deprecation Message

- Replaces all `interface{}` with `any` because its 2025.
- Caps max parallelism at 10 for write operations, and includes policies in that cap.
- Adds deprecation message for policy v1.

```
╷
│ Warning: Deprecated Resource
│
│   with data.border0_policy_document.test_tf_policy_document,
│   on main.tf line 86, in data "border0_policy_document" "test_tf_policy_document":
│   86: data "border0_policy_document" "test_tf_policy_document" {
│
│ `border0_policy_document` is deprecated. Use `border0_policy_v2_document` instead. The Border0 API will reject the creation of policies with v1 format and only allows updating existing v1 policies.
│
│ (and one more similar warning elsewhere)
╵
```

[ME-4907]: https://mysocket.atlassian.net/browse/ME-4907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ