### PR TITLE
[PRIV-52] Add Authentication fields to RDP

### DIFF
--- a/border0/resource_socket.go
+++ b/border0/resource_socket.go
@@ -461,6 +461,23 @@ func resourceSocket(semaphore *semaphore.Weighted) *schema.Resource {
 							Optional:    true,
 							Description: "The upstream RDP port number.",
 						},
+						"username": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Sensitive:   true,
+							Description: "The upstream RDP username.",
+						},
+						"password": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Sensitive:   true,
+							Description: "The upstream RDP password.",
+						},
+						"domain": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The upstream RDP domain.",
+						},
 					},
 				},
 			},

--- a/border0/resource_socket.go
+++ b/border0/resource_socket.go
@@ -464,7 +464,6 @@ func resourceSocket(semaphore *semaphore.Weighted) *schema.Resource {
 						"username": {
 							Type:        schema.TypeString,
 							Optional:    true,
-							Sensitive:   true,
 							Description: "The upstream RDP username.",
 						},
 						"password": {

--- a/docs/resources/socket.md
+++ b/docs/resources/socket.md
@@ -303,8 +303,11 @@ Optional:
 
 Optional:
 
+- `domain` (String) The upstream RDP domain.
 - `hostname` (String) The upstream RDP hostname.
+- `password` (String, Sensitive) The upstream RDP password.
 - `port` (Number) The upstream RDP port number.
+- `username` (String, Sensitive) The upstream RDP username.
 
 
 <a id="nestedblock--snowflake_configuration"></a>

--- a/docs/resources/socket.md
+++ b/docs/resources/socket.md
@@ -307,7 +307,7 @@ Optional:
 - `hostname` (String) The upstream RDP hostname.
 - `password` (String, Sensitive) The upstream RDP password.
 - `port` (Number) The upstream RDP port number.
-- `username` (String, Sensitive) The upstream RDP username.
+- `username` (String) The upstream RDP username.
 
 
 <a id="nestedblock--snowflake_configuration"></a>

--- a/internal/schemautil/socket/rdp/from_upstream_config.go
+++ b/internal/schemautil/socket/rdp/from_upstream_config.go
@@ -16,6 +16,9 @@ func FromUpstreamConfig(d *schema.ResourceData, config *service.RdpServiceConfig
 	data := map[string]any{
 		"hostname": config.Hostname,
 		"port":     config.Port,
+		"username": config.Username,
+		"password": config.Password,
+		"domain":   config.Domain,
 	}
 	if err := d.Set("rdp_configuration", []map[string]any{data}); err != nil {
 		return diagnostics.Error(err, `Failed to set "rdp_configuration"`)

--- a/internal/schemautil/socket/rdp/from_upstream_config_test.go
+++ b/internal/schemautil/socket/rdp/from_upstream_config_test.go
@@ -1,0 +1,113 @@
+package rdp
+
+import (
+	"testing"
+
+	"github.com/borderzero/border0-go/types/service"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFromUpstreamConfig_AllFields(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		"rdp_configuration": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"hostname": {Type: schema.TypeString, Optional: true},
+					"port":     {Type: schema.TypeInt, Optional: true},
+					"username": {Type: schema.TypeString, Optional: true},
+					"password": {Type: schema.TypeString, Optional: true},
+					"domain":   {Type: schema.TypeString, Optional: true},
+				},
+			},
+		},
+	}, map[string]any{})
+
+	config := &service.RdpServiceConfiguration{
+		HostnameAndPort: service.HostnameAndPort{
+			Hostname: "10.0.0.1",
+			Port:     3389,
+		},
+		UsernameAndPassword: service.UsernameAndPassword{
+			Username: "admin",
+			Password: "secret",
+		},
+		Domain: "corp.example.com",
+	}
+
+	diags := FromUpstreamConfig(d, config)
+	require.False(t, diags.HasError(), "Expected no errors")
+
+	rdpConfig := d.Get("rdp_configuration").([]any)
+	require.Len(t, rdpConfig, 1)
+
+	configMap := rdpConfig[0].(map[string]any)
+	assert.Equal(t, "10.0.0.1", configMap["hostname"])
+	assert.Equal(t, 3389, configMap["port"])
+	assert.Equal(t, "admin", configMap["username"])
+	assert.Equal(t, "secret", configMap["password"])
+	assert.Equal(t, "corp.example.com", configMap["domain"])
+}
+
+func TestFromUpstreamConfig_HostnameAndPortOnly(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		"rdp_configuration": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"hostname": {Type: schema.TypeString, Optional: true},
+					"port":     {Type: schema.TypeInt, Optional: true},
+					"username": {Type: schema.TypeString, Optional: true},
+					"password": {Type: schema.TypeString, Optional: true},
+					"domain":   {Type: schema.TypeString, Optional: true},
+				},
+			},
+		},
+	}, map[string]any{})
+
+	config := &service.RdpServiceConfiguration{
+		HostnameAndPort: service.HostnameAndPort{
+			Hostname: "10.0.0.1",
+			Port:     3389,
+		},
+	}
+
+	diags := FromUpstreamConfig(d, config)
+	require.False(t, diags.HasError(), "Expected no errors")
+
+	rdpConfig := d.Get("rdp_configuration").([]any)
+	require.Len(t, rdpConfig, 1)
+
+	configMap := rdpConfig[0].(map[string]any)
+	assert.Equal(t, "10.0.0.1", configMap["hostname"])
+	assert.Equal(t, 3389, configMap["port"])
+	assert.Equal(t, "", configMap["username"])
+	assert.Equal(t, "", configMap["password"])
+	assert.Equal(t, "", configMap["domain"])
+}
+
+func TestFromUpstreamConfig_NilConfig(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		"rdp_configuration": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"hostname": {Type: schema.TypeString, Optional: true},
+					"port":     {Type: schema.TypeInt, Optional: true},
+					"username": {Type: schema.TypeString, Optional: true},
+					"password": {Type: schema.TypeString, Optional: true},
+					"domain":   {Type: schema.TypeString, Optional: true},
+				},
+			},
+		},
+	}, map[string]any{})
+
+	diags := FromUpstreamConfig(d, nil)
+	require.True(t, diags.HasError(), "Expected error for nil config")
+	assert.Contains(t, diags[0].Summary, "not present")
+}

--- a/internal/schemautil/socket/rdp/to_upstream_config.go
+++ b/internal/schemautil/socket/rdp/to_upstream_config.go
@@ -27,6 +27,15 @@ func ToUpstreamConfig(d *schema.ResourceData, config *service.RdpServiceConfigur
 	if v, ok := data["port"]; ok {
 		config.Port = uint16(v.(int))
 	}
+	if v, ok := data["username"]; ok {
+		config.Username = v.(string)
+	}
+	if v, ok := data["password"]; ok {
+		config.Password = v.(string)
+	}
+	if v, ok := data["domain"]; ok {
+		config.Domain = v.(string)
+	}
 
 	return nil
 }

--- a/internal/schemautil/socket/rdp/to_upstream_config_test.go
+++ b/internal/schemautil/socket/rdp/to_upstream_config_test.go
@@ -1,0 +1,177 @@
+package rdp
+
+import (
+	"testing"
+
+	"github.com/borderzero/border0-go/types/service"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToUpstreamConfig_AllFields(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		"rdp_configuration": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"hostname": {Type: schema.TypeString, Optional: true},
+					"port":     {Type: schema.TypeInt, Optional: true},
+					"username": {Type: schema.TypeString, Optional: true},
+					"password": {Type: schema.TypeString, Optional: true},
+					"domain":   {Type: schema.TypeString, Optional: true},
+				},
+			},
+		},
+	}, map[string]any{
+		"rdp_configuration": []any{
+			map[string]any{
+				"hostname": "10.0.0.1",
+				"port":     3389,
+				"username": "admin",
+				"password": "secret",
+				"domain":   "corp.example.com",
+			},
+		},
+	})
+
+	config := &service.RdpServiceConfiguration{}
+	diags := ToUpstreamConfig(d, config)
+
+	require.False(t, diags.HasError(), "Expected no errors")
+	assert.Equal(t, "10.0.0.1", config.Hostname)
+	assert.Equal(t, uint16(3389), config.Port)
+	assert.Equal(t, "admin", config.Username)
+	assert.Equal(t, "secret", config.Password)
+	assert.Equal(t, "corp.example.com", config.Domain)
+}
+
+func TestToUpstreamConfig_HostnameAndPortOnly(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		"rdp_configuration": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"hostname": {Type: schema.TypeString, Optional: true},
+					"port":     {Type: schema.TypeInt, Optional: true},
+					"username": {Type: schema.TypeString, Optional: true},
+					"password": {Type: schema.TypeString, Optional: true},
+					"domain":   {Type: schema.TypeString, Optional: true},
+				},
+			},
+		},
+	}, map[string]any{
+		"rdp_configuration": []any{
+			map[string]any{
+				"hostname": "10.0.0.1",
+				"port":     3389,
+			},
+		},
+	})
+
+	config := &service.RdpServiceConfiguration{}
+	diags := ToUpstreamConfig(d, config)
+
+	require.False(t, diags.HasError(), "Expected no errors")
+	assert.Equal(t, "10.0.0.1", config.Hostname)
+	assert.Equal(t, uint16(3389), config.Port)
+	assert.Empty(t, config.Username)
+	assert.Empty(t, config.Password)
+	assert.Empty(t, config.Domain)
+}
+
+func TestToUpstreamConfig_UsernameAndPasswordWithoutDomain(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		"rdp_configuration": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"hostname": {Type: schema.TypeString, Optional: true},
+					"port":     {Type: schema.TypeInt, Optional: true},
+					"username": {Type: schema.TypeString, Optional: true},
+					"password": {Type: schema.TypeString, Optional: true},
+					"domain":   {Type: schema.TypeString, Optional: true},
+				},
+			},
+		},
+	}, map[string]any{
+		"rdp_configuration": []any{
+			map[string]any{
+				"hostname": "10.0.0.1",
+				"port":     3389,
+				"username": "admin",
+				"password": "secret",
+			},
+		},
+	})
+
+	config := &service.RdpServiceConfiguration{}
+	diags := ToUpstreamConfig(d, config)
+
+	require.False(t, diags.HasError(), "Expected no errors")
+	assert.Equal(t, "admin", config.Username)
+	assert.Equal(t, "secret", config.Password)
+	assert.Empty(t, config.Domain)
+}
+
+func TestToUpstreamConfig_EmptyConfig(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		"rdp_configuration": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"hostname": {Type: schema.TypeString, Optional: true},
+					"port":     {Type: schema.TypeInt, Optional: true},
+					"username": {Type: schema.TypeString, Optional: true},
+					"password": {Type: schema.TypeString, Optional: true},
+					"domain":   {Type: schema.TypeString, Optional: true},
+				},
+			},
+		},
+	}, map[string]any{})
+
+	config := &service.RdpServiceConfiguration{}
+	diags := ToUpstreamConfig(d, config)
+
+	require.False(t, diags.HasError(), "Expected no errors")
+	assert.Empty(t, config.Hostname)
+	assert.Equal(t, uint16(0), config.Port)
+	assert.Empty(t, config.Username)
+	assert.Empty(t, config.Password)
+	assert.Empty(t, config.Domain)
+}
+
+func TestToUpstreamConfig_NilConfig(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		"rdp_configuration": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"hostname": {Type: schema.TypeString, Optional: true},
+					"port":     {Type: schema.TypeInt, Optional: true},
+					"username": {Type: schema.TypeString, Optional: true},
+					"password": {Type: schema.TypeString, Optional: true},
+					"domain":   {Type: schema.TypeString, Optional: true},
+				},
+			},
+		},
+	}, map[string]any{
+		"rdp_configuration": []any{
+			map[string]any{
+				"hostname": "10.0.0.1",
+				"port":     3389,
+				"username": "admin",
+				"password": "secret",
+			},
+		},
+	})
+
+	// passing nil config should not panic
+	diags := ToUpstreamConfig(d, nil)
+	require.False(t, diags.HasError(), "Expected no errors")
+}


### PR DESCRIPTION
# Description
RDP service is missing the authenticaiton fields: domain/username/password, so this PR adds them