### PR TITLE
[PRIV-397] Bump gRPC to v1.83.1 for GHSA-hrxh-6v49-42gf

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -85,9 +85,9 @@ require (
 	golang.org/x/text v0.40.0 // indirect
 	golang.org/x/tools v0.47.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
-	google.golang.org/grpc v1.79.3 // indirect
-	google.golang.org/protobuf v1.36.10 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
+	google.golang.org/grpc v1.83.1 // indirect
+	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
## [PRIV-397](https://mysocket.atlassian.net/browse/PRIV-397)

Updates `google.golang.org/grpc` from v1.79.3 to v1.83.1, satisfying GHSA-hrxh-6v49-42gf (requires v1.82.1 or newer). Go resolves required indirect `google.golang.org/genproto/googleapis/rpc` and `google.golang.org/protobuf` updates.

## Testing

`go mod verify`, `go test ./internal/schemautil/socket/...`, and `git diff --check` pass. `go test ./border0` is blocked by a missing go.sum entry for `google.golang.org/protobuf/reflect/protoreflect`; the run allowlist permits `go.mod` only, so the required go.sum refresh could not be retained.

References: PRIV-397, GHSA-hrxh-6v49-42gf.

[PRIV-397]: https://tailscale.atlassian.net/browse/PRIV-397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ